### PR TITLE
DMVP-28: MongoDB network peering

### DIFF
--- a/modules/mongodb-atlas/network.tf
+++ b/modules/mongodb-atlas/network.tf
@@ -5,3 +5,28 @@ resource "mongodbatlas_project_ip_access_list" "ip-access-list" {
   ip_address = each.value
   comment    = "ip address range items"
 }
+
+resource "aws_default_vpc" "default" {
+  tags = {
+    Name = "Default VPC"
+  }
+}
+
+resource "mongodbatlas_network_peering" "mongo_peer" {
+  accepter_region_name   = "eu-central-1"
+  project_id             = mongodbatlas_project.main.id
+  container_id           = mongodbatlas_cluster.main.container_id
+  provider_name          = "AWS"
+  route_table_cidr_block = var.route_table_cidr_block
+  vpc_id                 = aws_default_vpc.default.id
+  aws_account_id         = var.aws_account_id
+}
+
+resource "aws_vpc_peering_connection_accepter" "aws_peer" {
+  vpc_peering_connection_id = mongodbatlas_network_peering.mongo_peer.connection_id
+  auto_accept               = true
+
+  tags = {
+    Side = "Accepter"
+  }
+}

--- a/modules/mongodb-atlas/network.tf
+++ b/modules/mongodb-atlas/network.tf
@@ -7,10 +7,10 @@ resource "mongodbatlas_project_ip_access_list" "ip-access-list" {
 }
 
 resource "mongodbatlas_network_peering" "mongo_peer" {
-  accepter_region_name   = "eu-central-1"
+  accepter_region_name   = var.accepter_region_name
   project_id             = mongodbatlas_project.main.id
   container_id           = mongodbatlas_cluster.main.container_id
-  provider_name          = "AWS"
+  provider_name          = var.provider_name
   route_table_cidr_block = var.route_table_cidr_block
   vpc_id                 = var.vpc_id
   aws_account_id         = var.aws_account_id

--- a/modules/mongodb-atlas/network.tf
+++ b/modules/mongodb-atlas/network.tf
@@ -6,19 +6,13 @@ resource "mongodbatlas_project_ip_access_list" "ip-access-list" {
   comment    = "ip address range items"
 }
 
-resource "aws_default_vpc" "default" {
-  tags = {
-    Name = "Default VPC"
-  }
-}
-
 resource "mongodbatlas_network_peering" "mongo_peer" {
   accepter_region_name   = "eu-central-1"
   project_id             = mongodbatlas_project.main.id
   container_id           = mongodbatlas_cluster.main.container_id
   provider_name          = "AWS"
   route_table_cidr_block = var.route_table_cidr_block
-  vpc_id                 = aws_default_vpc.default.id
+  vpc_id                 = var.vpc_id
   aws_account_id         = var.aws_account_id
 }
 

--- a/modules/mongodb-atlas/variables.tf
+++ b/modules/mongodb-atlas/variables.tf
@@ -53,3 +53,8 @@ variable route_table_cidr_block {
   default     = "192.168.240.0/21"
   description = "AWS VPC CIDR block or subnet."
 }
+
+variable vpc_id {
+  type = string
+  default = "vpc-0cb8c765b4b58b790"
+}

--- a/modules/mongodb-atlas/variables.tf
+++ b/modules/mongodb-atlas/variables.tf
@@ -8,6 +8,11 @@ variable private_key {
   description = "MongoDB Atlas organisation private key"
 }
 
+variable aws_account_id {
+  type        = string
+  description = "AWS user ID"
+}
+
 variable org_id {
   type        = string
   description = "MongoDB Atlas Organisation ID"
@@ -41,4 +46,10 @@ variable ip_addresses {
   type        = list(string)
   default     = []
   description = "MongoDB Atlas IP Access List"
+}
+
+variable route_table_cidr_block {
+  type        = string
+  default     = "192.168.240.0/21"
+  description = "AWS VPC CIDR block or subnet."
 }

--- a/modules/mongodb-atlas/variables.tf
+++ b/modules/mongodb-atlas/variables.tf
@@ -55,6 +55,19 @@ variable route_table_cidr_block {
 }
 
 variable vpc_id {
-  type = string
-  default = "vpc-0cb8c765b4b58b790"
+  type        = string
+  default     = "vpc-0cb8c765b4b58b790"
+  description = "Unique identifier of the peer VPC."
+}
+
+variable accepter_region_name {
+  type        = string
+  default     = "eu-central-1"
+  description = "Specifies the region where the peer VPC resides."
+}
+
+variable provider_name {
+  type        = string
+  default     = "AWS"
+  description = "Cloud provider to whom the peering connection is being made."
 }


### PR DESCRIPTION
Why
AWS EKS containers cannot connect to Mongodb without access setup and there is no way to see outbound ip addresses of EKS nodes.

How
Seem to be network peering is the best way to connect mongodb and eks.



https://tutorbot.atlassian.net/browse/DMVP-28